### PR TITLE
Added link for Contribution Guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,11 +10,11 @@ Remove this line and tell us how the code was tested.
 ## Checklist:
 Before you create this PR, confirm all the requirements listed below by checking the checkboxes `[x]`:
 
--   [ ] I have followed the [Contribution Guidelines]() while contributing.
+-   [ ] I have followed the [Contribution Guidelines](https://github.com/BugBustersCommunity/website#how-to-contribute) while contributing.
 -   [ ] I have checked there aren't other open [Pull Requests](https://github.com/BugBustersCommunity/website/pulls) for the same update/change.
 -   [ ] I have made corresponding changes to the documentation.
 -   [ ] I have tested the code before submission.
--   [ ] I have formatted the code . (You can use any html,css beautifier)
+-   [ ] I have formatted the code . (You can use any html, css beautifier)
 -   [ ] My changes generates no new warnings.
 -   [ ] I'm HSOC22 contributor.
 -   [ ] I have commented my code, particularly in hard-to-understand areas.


### PR DESCRIPTION


## What is the change?
Minor changes, Added the link for Contribution Guidelines for the Pull Request Template.

## Related issue?

## How was it tested?


## Checklist:
Before you create this PR, confirm all the requirements listed below by checking the checkboxes `[x]`:

-   [x] I have followed the [Contribution Guidelines]() while contributing.
-   [x] I have checked there aren't other open [Pull Requests](https://github.com/BugBustersCommunity/website/pulls) for the same update/change.
-   [x] I have made corresponding changes to the documentation.
-   [x] I have tested the code before submission.
-   [x] I have formatted the code . (You can use any html,css beautifier)
-   [x] My changes generates no new warnings.
-   [ ] I'm HSOC22 contributor.
-   [x] I have commented my code, particularly in hard-to-understand areas.


## GIF/video of the working of component you created:

